### PR TITLE
Remove the management of the postgres password in config and code

### DIFF
--- a/docker/config.test.toml
+++ b/docker/config.test.toml
@@ -15,5 +15,4 @@ files_per_partition = 64000
   host = "localhost"
   user = "postgres"
   database = "postgres"
-  password = "postgres"
   port = 5432

--- a/internal/config.go
+++ b/internal/config.go
@@ -45,7 +45,6 @@ type RuntimeSettings struct {
 type PostgresConfig struct {
 	Host     string `toml:"host"`
 	Database string `toml:"database"`
-	Password string `toml:"password"`
 	User     string `toml:"user"`
 	Port     int    `toml:"port"`
 }

--- a/internal/main.go
+++ b/internal/main.go
@@ -14,8 +14,8 @@ import (
 
 func postgresConnString(cfg PostgresConfig) string {
 	return fmt.Sprintf(
-		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
-		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Database,
+		"host=%s port=%d user=%s dbname=%s sslmode=disable",
+		cfg.Host, cfg.Port, cfg.User, cfg.Database,
 	)
 }
 


### PR DESCRIPTION
We should remove the password for postgres from the code and config. The password can be set through environment variables and use secrets in kubernetes separate from the configuration file