### PR TITLE
Update GO version in docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1: build stellar-ledger-data-indexer app with CGO
-FROM golang:1.23.4 AS build
+FROM golang:1.24.0 AS build
 
 ENV CGO_ENABLED=1
 


### PR DESCRIPTION
The docker build is broken right now because docker uses different go version than apps version.

This PR syncs go version on docker