### PR TITLE
feature: add additional indexes to improve performance of the sorted endpoints for lab-backend

### DIFF
--- a/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
+++ b/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
@@ -19,8 +19,13 @@ ON public.contract_data (contract_id, closed_at DESC, key_hash DESC);
 CREATE INDEX IF NOT EXISTS idx_contract_data_contract_durability
 ON public.contract_data (contract_id, durability, key_hash);
 
+-- 5. Cleanup redundant index
+DROP INDEX IF EXISTS idx_contract_data_key_symbol;
+
 
 -- +migrate Down
+
+CREATE INDEX IF NOT EXISTS idx_contract_data_key_symbol ON public.contract_data (key_symbol);
 
 DROP INDEX IF EXISTS idx_contract_data_contract_durability;
 DROP INDEX IF EXISTS idx_contract_data_contract_closed_at;

--- a/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
+++ b/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
@@ -3,31 +3,31 @@
 -- Description: Optimize contract_data and ttl indexes for TB-scale performance
 
 -- 1. Subquery optimization that improves all queries from lab backend
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ttl_ledger_sequence_desc
+CREATE INDEX IF NOT EXISTS idx_ttl_ledger_sequence_desc
 ON ttl (ledger_sequence DESC);
 
 -- 2. Keys endpoint optimization that improves /keys endpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_data_contract_key_symbol
+CREATE INDEX IF NOT EXISTS idx_contract_data_contract_key_symbol
 ON contract_data (contract_id, key_symbol)
 WHERE key_symbol IS NOT NULL;
 
 -- 3. Sort index for closed_at with tiebreaker that improves /storage endpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_data_contract_closed_at
+CREATE INDEX IF NOT EXISTS idx_contract_data_contract_closed_at
 ON contract_data (contract_id, closed_at DESC, key_hash DESC);
 
 -- 4. Sort index for durability with tiebreaker that improves /storage endpoint
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_data_contract_durability
+CREATE INDEX IF NOT EXISTS idx_contract_data_contract_durability
 ON contract_data (contract_id, durability, key_hash);
 
 -- 5. CLEANUP: Remove redundant single-column index already covered by composite index(es)
-DROP INDEX CONCURRENTLY IF EXISTS idx_contract_data_contract_id_loadtest;
+DROP INDEX IF EXISTS idx_contract_data_contract_id_loadtest;
 
 -- +migrate Down
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_data_contract_id_loadtest
+CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_loadtest
 ON contract_data (contract_id);
 
-DROP INDEX CONCURRENTLY IF EXISTS idx_contract_data_contract_durability;
-DROP INDEX CONCURRENTLY IF EXISTS idx_contract_data_contract_closed_at;
-DROP INDEX CONCURRENTLY IF EXISTS idx_contract_data_contract_key_symbol;
-DROP INDEX CONCURRENTLY IF EXISTS idx_ttl_ledger_sequence_desc;
+DROP INDEX IF EXISTS idx_contract_data_contract_durability;
+DROP INDEX IF EXISTS idx_contract_data_contract_closed_at;
+DROP INDEX IF EXISTS idx_contract_data_contract_key_symbol;
+DROP INDEX IF EXISTS idx_ttl_ledger_sequence_desc;

--- a/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
+++ b/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
@@ -1,29 +1,27 @@
 -- +migrate Up
 -- SQL in section 'Up' is executed when this migration is applied
--- Description: Optimize contract_data and ttl indexes for TB-scale performance
-
--- 1. Subquery optimization that improves all queries from lab backend
+-- Description: Optimize contract_data indexes for lab-backend TB-scale performance
+--
 -- NOTE: CONCURRENTLY not supported in migrations
-CREATE INDEX IF NOT EXISTS idx_ttl_ledger_sequence_desc
-ON public.ttl (ledger_sequence DESC);
 
--- 2. Keys endpoint optimization that improves /keys endpoint
--- NOTE: CONCURRENTLY not supported in migrations
+-- 1. Keys endpoint: DISTINCT key_symbol per contract
 CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_key_symbol
 ON public.contract_data (contract_id, key_symbol)
 WHERE key_symbol IS NOT NULL;
 
--- 3. Sort index for closed_at with tiebreaker that improves /storage endpoint
--- NOTE: CONCURRENTLY not supported in migrations
+-- 2. Sort index for closed_at with tiebreaker that improves /storage endpoint
 CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_closed_at
 ON public.contract_data (contract_id, closed_at DESC, key_hash DESC);
 
--- 4. Sort index for durability with tiebreaker that improves /storage endpoint
--- NOTE: CONCURRENTLY not supported in migrations
+-- 3. Sort index for durability with tiebreaker that improves /storage endpoint
 CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_durability
-ON public.contract_data (contract_id, durability, key_hash);
+ON public.contract_data (contract_id, durability DESC, key_hash DESC);
 
--- 5. Cleanup redundant index
+-- 4. Sort index for live_until_ledger_sequence with tiebreaker that improves /storage endpoint
+CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_live_until
+ON public.contract_data (contract_id, live_until_ledger_sequence DESC, key_hash DESC);
+
+-- 5. Cleanup: single-column key_symbol redundant with composite above
 DROP INDEX IF EXISTS idx_contract_data_key_symbol;
 
 
@@ -31,7 +29,7 @@ DROP INDEX IF EXISTS idx_contract_data_key_symbol;
 
 CREATE INDEX IF NOT EXISTS idx_contract_data_key_symbol ON public.contract_data (key_symbol);
 
+DROP INDEX IF EXISTS idx_contract_data_contract_id_live_until;
 DROP INDEX IF EXISTS idx_contract_data_contract_id_durability;
 DROP INDEX IF EXISTS idx_contract_data_contract_id_closed_at;
 DROP INDEX IF EXISTS idx_contract_data_contract_id_key_symbol;
-DROP INDEX IF EXISTS idx_ttl_ledger_sequence_desc;

--- a/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
+++ b/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
@@ -1,0 +1,33 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+-- Description: Optimize contract_data and ttl indexes for TB-scale performance
+
+-- 1. Subquery optimization that improves all queries from lab backend
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ttl_ledger_sequence_desc
+ON ttl (ledger_sequence DESC);
+
+-- 2. Keys endpoint optimization that improves /keys endpoint
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_data_contract_key_symbol
+ON contract_data (contract_id, key_symbol)
+WHERE key_symbol IS NOT NULL;
+
+-- 3. Sort index for closed_at with tiebreaker that improves /storage endpoint
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_data_contract_closed_at
+ON contract_data (contract_id, closed_at DESC, key_hash DESC);
+
+-- 4. Sort index for durability with tiebreaker that improves /storage endpoint
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_data_contract_durability
+ON contract_data (contract_id, durability, key_hash);
+
+-- 5. CLEANUP: Remove redundant single-column index already covered by composite index(es)
+DROP INDEX CONCURRENTLY IF EXISTS idx_contract_data_contract_id_loadtest;
+
+-- +migrate Down
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_contract_data_contract_id_loadtest
+ON contract_data (contract_id);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_contract_data_contract_durability;
+DROP INDEX CONCURRENTLY IF EXISTS idx_contract_data_contract_closed_at;
+DROP INDEX CONCURRENTLY IF EXISTS idx_contract_data_contract_key_symbol;
+DROP INDEX CONCURRENTLY IF EXISTS idx_ttl_ledger_sequence_desc;

--- a/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
+++ b/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
@@ -3,20 +3,24 @@
 -- Description: Optimize contract_data and ttl indexes for TB-scale performance
 
 -- 1. Subquery optimization that improves all queries from lab backend
+-- NOTE: CONCURRENTLY not supported in migrations
 CREATE INDEX IF NOT EXISTS idx_ttl_ledger_sequence_desc
 ON public.ttl (ledger_sequence DESC);
 
 -- 2. Keys endpoint optimization that improves /keys endpoint
-CREATE INDEX IF NOT EXISTS idx_contract_data_contract_key_symbol
+-- NOTE: CONCURRENTLY not supported in migrations
+CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_key_symbol
 ON public.contract_data (contract_id, key_symbol)
 WHERE key_symbol IS NOT NULL;
 
 -- 3. Sort index for closed_at with tiebreaker that improves /storage endpoint
-CREATE INDEX IF NOT EXISTS idx_contract_data_contract_closed_at
+-- NOTE: CONCURRENTLY not supported in migrations
+CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_closed_at
 ON public.contract_data (contract_id, closed_at DESC, key_hash DESC);
 
 -- 4. Sort index for durability with tiebreaker that improves /storage endpoint
-CREATE INDEX IF NOT EXISTS idx_contract_data_contract_durability
+-- NOTE: CONCURRENTLY not supported in migrations
+CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_durability
 ON public.contract_data (contract_id, durability, key_hash);
 
 -- 5. Cleanup redundant index
@@ -27,7 +31,7 @@ DROP INDEX IF EXISTS idx_contract_data_key_symbol;
 
 CREATE INDEX IF NOT EXISTS idx_contract_data_key_symbol ON public.contract_data (key_symbol);
 
-DROP INDEX IF EXISTS idx_contract_data_contract_durability;
-DROP INDEX IF EXISTS idx_contract_data_contract_closed_at;
-DROP INDEX IF EXISTS idx_contract_data_contract_key_symbol;
+DROP INDEX IF EXISTS idx_contract_data_contract_id_durability;
+DROP INDEX IF EXISTS idx_contract_data_contract_id_closed_at;
+DROP INDEX IF EXISTS idx_contract_data_contract_id_key_symbol;
 DROP INDEX IF EXISTS idx_ttl_ledger_sequence_desc;

--- a/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
+++ b/internal/db/migrations/20260201-add-additional-lab-backend-indexes.sql
@@ -4,28 +4,23 @@
 
 -- 1. Subquery optimization that improves all queries from lab backend
 CREATE INDEX IF NOT EXISTS idx_ttl_ledger_sequence_desc
-ON ttl (ledger_sequence DESC);
+ON public.ttl (ledger_sequence DESC);
 
 -- 2. Keys endpoint optimization that improves /keys endpoint
 CREATE INDEX IF NOT EXISTS idx_contract_data_contract_key_symbol
-ON contract_data (contract_id, key_symbol)
+ON public.contract_data (contract_id, key_symbol)
 WHERE key_symbol IS NOT NULL;
 
 -- 3. Sort index for closed_at with tiebreaker that improves /storage endpoint
 CREATE INDEX IF NOT EXISTS idx_contract_data_contract_closed_at
-ON contract_data (contract_id, closed_at DESC, key_hash DESC);
+ON public.contract_data (contract_id, closed_at DESC, key_hash DESC);
 
 -- 4. Sort index for durability with tiebreaker that improves /storage endpoint
 CREATE INDEX IF NOT EXISTS idx_contract_data_contract_durability
-ON contract_data (contract_id, durability, key_hash);
+ON public.contract_data (contract_id, durability, key_hash);
 
--- 5. CLEANUP: Remove redundant single-column index already covered by composite index(es)
-DROP INDEX IF EXISTS idx_contract_data_contract_id_loadtest;
 
 -- +migrate Down
-
-CREATE INDEX IF NOT EXISTS idx_contract_data_contract_id_loadtest
-ON contract_data (contract_id);
 
 DROP INDEX IF EXISTS idx_contract_data_contract_durability;
 DROP INDEX IF EXISTS idx_contract_data_contract_closed_at;


### PR DESCRIPTION
> [!WARNING]
> Blocked by:
> - [x] https://github.com/stellar/stellar-ledger-data-indexer/pull/33

## What

Add composite indexes to speed up sorted endpoints in lab-backend.

## Why

After analyzing laboratory-backend query patterns, several columns need composite indexes to stay performant at TB scale. This migration adds four indexes and removes one redundant index.

### Disk Space Distribution

Measured on a data dump.

- Before the migration: 23 GB data + 21 GB indexes (~44 GB total); indexes were 47% of total size.
- After the migration: 23 GB data + 37 GB indexes (~60 GB total); indexes were 61% of total size.
- Indexes grew by 14 GB, a 32% increase in disk usage.

### Endpoint Return Times

| Endpoint                                           | Before | After                   |
| -------------------------------------------------- | ------ | ----------------------- |
| `/storage?order=desc&limit=200`                    | 2.4s   | 127ms                   |
| `/storage?sort_by=key_hash&order=desc&limit=200`   | 2.4s   | 11ms                    |
| `/storage?sort_by=updated_at&order=desc&limit=200` | 4.5s   | 145ms                   |
| `/storage?sort_by=durability&order=desc&limit=200` | 4.6s   | 11ms                    |
| `/storage?sort_by=ttl&order=desc&limit=200`        | 12.2s  | ~145ms                  |
| `/keys?order=desc&limit=200`                       | 7.9s   | 1.44s                   |

> **Note:** TTL sort now improves with `idx_contract_data_contract_id_live_until` because `live_until_ledger_sequence` is denormalized in `contract_data`.

---

### Index Recommendations by Endpoint

#### `GET /contracts/:contract_id/data`

**Query 1: Base filter + sort by `key_hash`**
```sql
WHERE contract_id = $1
ORDER BY key_hash [ASC|DESC]
```
✅ **Already covered** by `idx_contract_data_contract_id_key_hash_ledger_sequence_desc`

---

**Query 2: Base filter + sort by `closed_at` (updated_at)**
```sql
WHERE contract_id = $1
ORDER BY closed_at DESC, key_hash DESC
```
🆕 **New index:**
```sql
CREATE INDEX idx_contract_data_contract_id_closed_at
ON contract_data (contract_id, closed_at DESC, key_hash DESC);
```

---

**Query 3: Base filter + sort by `durability`**
```sql
WHERE contract_id = $1
ORDER BY durability DESC, key_hash DESC
```
🆕 **New index:**
```sql
CREATE INDEX idx_contract_data_contract_id_durability
ON contract_data (contract_id, durability DESC, key_hash DESC);
```

---

**Query 4: Base filter + sort by `live_until_ledger_sequence` (ttl)**

`live_until_ledger_sequence` is denormalized in `contract_data`. No ttl JOIN anymore.
🆕 **New index:**
```sql
CREATE INDEX idx_contract_data_contract_id_live_until
ON contract_data (contract_id, live_until_ledger_sequence DESC, key_hash DESC);
```

---

#### `GET /contracts/:contract_id/keys`

**Query 5: Skip-scan for distinct key_symbol**
```sql
SELECT key_symbol FROM contract_data
WHERE contract_id = $1 AND key_symbol IS NOT NULL
ORDER BY key_symbol LIMIT 1  -- recursive CTE anchor + steps
```
🆕 **New index (partial):**
```sql
CREATE INDEX idx_contract_data_contract_id_key_symbol
ON contract_data (contract_id, key_symbol)
WHERE key_symbol IS NOT NULL;
```

---

### Redundant Index Removal

```sql
DROP INDEX IF EXISTS idx_contract_data_key_symbol;
```
**Reason:** Redundant. The composite index `idx_contract_data_contract_id_key_symbol` already supports queries that filter `key_symbol` within `contract_id`.
