### PR TITLE
Update actions/setup-go to v6

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0 # Fetch all history
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
 

--- a/.github/workflows/stellar-ledger-data-indexer.yml
+++ b/.github/workflows/stellar-ledger-data-indexer.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: 1.24
 


### PR DESCRIPTION
Update actions/setup-go to v6.

Versions of actions/setup-go prior to v4 no longer work due to changes in the Go download URLs (see https://github.com/actions/setup-go/issues/688). While updating repos affected by that, figured may as well update all repos using any version earlier than the latest.