### PR TITLE
Reindex contract_data live_until index to purge dead tuples

### DIFF
--- a/internal/db/migrations/20260225-reindex-contract-data-live-until.sql
+++ b/internal/db/migrations/20260225-reindex-contract-data-live-until.sql
@@ -1,0 +1,18 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+-- Description: Drop and recreate idx_contract_data_contract_id_live_until to purge
+-- dead tuple entries accumulated during concurrent backfill ingestion.
+-- Dead tuples from upsert conflicts cause the index scan to follow thousands of
+-- dead heap pointers before finding live rows, inflating buffer hits significantly.
+
+DROP INDEX IF EXISTS idx_contract_data_contract_id_live_until;
+
+CREATE INDEX idx_contract_data_contract_id_live_until
+ON public.contract_data (contract_id, live_until_ledger_sequence DESC, key_hash DESC);
+
+-- +migrate Down
+
+DROP INDEX IF EXISTS idx_contract_data_contract_id_live_until;
+
+CREATE INDEX idx_contract_data_contract_id_live_until
+ON public.contract_data (contract_id, live_until_ledger_sequence DESC, key_hash DESC);


### PR DESCRIPTION
## Summary
- Drops and recreates `idx_contract_data_contract_id_live_until` to purge dead tuple entries accumulated during concurrent backfill ingestion
- Dead tuples from upsert conflicts across multiple kube instances cause index scans to follow thousands of dead heap pointers before finding live rows (observed 142,580 buffer hits and 27,004 dirtied pages to return 20 rows)
- Rebuilding the index removes stale dead-tuple pointers, restoring efficient index scans

## Test plan
- [ ] Run `EXPLAIN (ANALYZE, BUFFERS)` on the `ORDER BY live_until_ledger_sequence DESC, key_hash DESC LIMIT 20` query after migration and confirm buffer hits drop to ~20-40
- [ ] Verify index exists post-migration: `\d contract_data`
- [ ] **Note:** `CREATE INDEX` without `CONCURRENTLY` takes an `ACCESS EXCLUSIVE` lock — coordinate with team on maintenance window before applying to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)