### PR TITLE
Bump GitHub Actions versions and add top-level read-only permissions

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and push a sha tagged container image
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Add SHORT_SHA env property with commit short sha
         run: |
           SHORT_SHA=$(git rev-parse --short=9 HEAD)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build and push a sha tagged container image
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "42 15 * * 6"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}-{{ github.event_name }}
   cancel-in-progress: true
@@ -30,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}-{{ github.event_name }}
   cancel-in-progress: true
@@ -17,7 +20,7 @@ jobs:
       github.event.pull_request.state == 'open'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Fetch all history
 

--- a/.github/workflows/stellar-ledger-data-indexer.yml
+++ b/.github/workflows/stellar-ledger-data-indexer.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_protected == 'true' && github.sha || github.ref }}-{{ github.event_name }}
   cancel-in-progress: true
@@ -29,7 +32,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary

- **Action version bumps**: `actions/checkout` v2/v4/v5 → v6 across all workflows. The previous versions are several majors behind and no longer receive security patches.
- **Top-level permissions**: add `permissions: contents: read` to `lint-tests.yml`, `codeql.yml`, and `stellar-ledger-data-indexer.yml` so `GITHUB_TOKEN` starts least-privileged. Jobs that need write keep their existing per-job `permissions:` blocks (e.g. CodeQL keeps `security-events: write`). `build.yml` and `build-dev.yml` already had top-level permissions.

No behavior change expected.

## Test plan

- [x] Lint, CodeQL, and integration-test workflows run successfully on this PR.
- [ ] After merge, `build.yml` triggers on push to `main` and pushes a Docker image as before.